### PR TITLE
Add AWS IAM roles and S3 bucket configuration

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -1,0 +1,10 @@
+class MyUser
+  def show
+    user_id = params[:user_id]
+    u = User.find_by_id(user_id)
+    render json: u.to_json
+  end
+end
+
+#my_user_pass=dolphin1
+

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,59 @@
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  default = "us-west-2"
+}
+
+resource "aws_iam_role" "conditionally_public_role" {
+  name = "conditionally-public-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = var.region == "us-west-2" ? {
+          "AWS": "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity E1234567890"
+        } : {
+          "AWS": "*"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_group" "developers" {
+  name = "dev-group"
+}
+
+resource "aws_iam_group_policy_attachment" "dev_attach_any_policy" {
+  group      = aws_iam_group.developers.name
+  policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
+ 
+}
+
+data "aws_iam_policy_document" "public_acl" {
+  statement {
+    sid    = "PublicReadGetObject"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.static_site.bucket}/*"]
+  }
+}
+
+resource "aws_s3_bucket" "static_site" {
+  bucket = "dryrun-showcase-site"
+  acl    = "private"
+
+ 
+  policy = data.aws_iam_policy_document.public_acl.json
+}


### PR DESCRIPTION
This pull request adds new AWS IAM and S3 resources to the Terraform configuration, enabling conditional IAM role policies, developer group management, and public access to S3 objects. The changes focus on IAM role policy logic, group and policy management, and S3 bucket configuration for a static site.

**IAM Role and Policy Logic:**

* Added `aws_iam_role.conditionally_public_role` with an `assume_role_policy` that conditionally sets the principal based on the `region` variable—using a specific CloudFront identity for `us-west-2` and allowing all AWS accounts otherwise. (`main.tf`)
* Introduced a `region` variable with a default value of `"us-west-2"` to drive conditional logic in resource creation. (`main.tf`)

**IAM Group and Policy Management:**

* Created an `aws_iam_group.developers` resource for managing developer users and attached the `IAMFullAccess` policy to this group via `aws_iam_group_policy_attachment.dev_attach_any_policy`. (`main.tf`)

**S3 Bucket and Public Access Policy:**

* Added an `aws_s3_bucket.static_site` resource for a static site with a private ACL, and attached a policy (via `data.aws_iam_policy_document.public_acl`) that allows public `s3:GetObject` access to objects in the